### PR TITLE
Add more meaningful messages to Errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,11 @@
 module.exports = function (req, time) {
 	if (req.timeoutTimer) { return req; }
 
+	var host = req._headers ? (' to ' + req._headers.host) : '';
+
 	req.timeoutTimer = setTimeout(function timeoutHandler() {
 		req.abort();
-		var e = new Error('ETIMEDOUT');
+		var e = new Error('Connection timed out on request' + host);
 		e.code = 'ETIMEDOUT';
 		req.emit('error', e);
 	}, time);
@@ -14,7 +16,7 @@ module.exports = function (req, time) {
 	// server freeze after sending headers
 	req.setTimeout(time, function socketTimeoutHandler() {
 		req.abort();
-		var e = new Error('ESOCKETTIMEDOUT');
+		var e = new Error('Socket timed out on request' + host);
 		e.code = 'ESOCKETTIMEDOUT';
 		req.emit('error', e);
 	});

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Timeout HTTP/HTTPS requests
 
-Emit `ETIMEDOUT` or `ESOCKETTIMEDOUT` when ClientRequest is hanged.
+Emit Error object with `code` property equal `ETIMEDOUT` or `ESOCKETTIMEDOUT` when ClientRequest is hanged.
 
 ## Usage
 

--- a/test.js
+++ b/test.js
@@ -22,6 +22,7 @@ it('should emit ETIMEDOUT when time is not enough', function (done) {
 
 	req.on('error', function (err) {
 		if (err.code === 'ETIMEDOUT') {
+			assert.equal(err.message, 'Connection timed out on request to google.com');
 			done();
 		}
 	});
@@ -55,6 +56,7 @@ describe('when only headers was sent', function () {
 
 		req.on('error', function (err) {
 			if (err.code === 'ESOCKETTIMEDOUT') {
+				assert.equal(err.message, 'Socket timed out on request to 0.0.0.0:8081');
 				done();
 			}
 		});


### PR DESCRIPTION
We have hard time today to dig out, what caused Error, because of short stacktrace from [request](https://github.com/request/request/blob/master/request.js#L919). It returns only message, what type of Error happened and no url to determine, which part of application failed.

I changed Error messages to have more meaningful messages, but `code` property remains the same.
