### PR TITLE
Allow specifying individual connect/socket timeouts

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,14 +5,17 @@ module.exports = function (req, time) {
 		return req;
 	}
 
+	var delays = isNaN(time) ? time : {socket: time, connect: time};
 	var host = req._headers ? (' to ' + req._headers.host) : '';
 
-	req.timeoutTimer = setTimeout(function timeoutHandler() {
-		req.abort();
-		var e = new Error('Connection timed out on request' + host);
-		e.code = 'ETIMEDOUT';
-		req.emit('error', e);
-	}, time);
+	if (delays.connect) {
+		req.timeoutTimer = setTimeout(function timeoutHandler() {
+			req.abort();
+			var e = new Error('Connection timed out on request' + host);
+			e.code = 'ETIMEDOUT';
+			req.emit('error', e);
+		}, delays.connect);
+	}
 
 	// Clear the connection timeout timer once a socket is assigned to the
 	// request and is connected. Abort the request if there is no activity
@@ -20,12 +23,15 @@ module.exports = function (req, time) {
 	req.on('socket', function assign(socket) {
 		socket.on('connect', function connect() {
 			clear();
-			socket.setTimeout(time, function socketTimeoutHandler() {
-				req.abort();
-				var e = new Error('Socket timed out on request' + host);
-				e.code = 'ESOCKETTIMEDOUT';
-				req.emit('error', e);
-			});
+
+			if (delays.socket) {
+				socket.setTimeout(delays.socket, function socketTimeoutHandler() {
+					req.abort();
+					var e = new Error('Socket timed out on request' + host);
+					e.code = 'ESOCKETTIMEDOUT';
+					req.emit('error', e);
+				});
+			}
 		});
 	});
 

--- a/test.js
+++ b/test.js
@@ -90,6 +90,42 @@ describe('when connection is established', function () {
 			}
 		});
 
-		timeout(req, 200);
+		timeout(req, {socket: 200, connect: 50});
+	});
+
+	it('should be able to only apply connect timeout', function (done) {
+		server.once('request', function (req, res) {
+			setTimeout(function () {
+				res.writeHead(200);
+				res.end('data');
+			}, 100);
+		});
+
+		var req = http.get('http://0.0.0.0:8081');
+
+		req.on('error', done);
+		req.on('finish', done);
+
+		timeout(req, {connect: 50});
+	});
+
+	it('should be able to only apply socket timeout', function (done) {
+		server.once('request', function (req, res) {
+			setTimeout(function () {
+				res.writeHead(200);
+				res.end('data');
+			}, 200);
+		});
+
+		var req = http.get('http://0.0.0.0:8081');
+
+		req.on('error', function (err) {
+			if (err.code === 'ESOCKETTIMEDOUT') {
+				assert.equal(err.message, 'Socket timed out on request to 0.0.0.0:8081');
+				done();
+			}
+		});
+
+		timeout(req, {socket: 50});
 	});
 });


### PR DESCRIPTION
As #5 outlines - it would be nice to allow specifying individual connect and socket timeouts.

This PR introduces this in a backwards-compatible way. If you pass a number, it'll use the same delay for both. If you specify an object, it allows you to set individual delays. If you pass an object with only one of the delays defined, it will only apply that timeout.
