### PR TITLE
Fix cases where socket is already connected

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,14 +20,13 @@ module.exports = function (req, time) {
 	// Clear the connection timeout timer once a socket is assigned to the
 	// request and is connected.
 	req.on('socket', function assign(socket) {
-		// Socket may come from Agent pool and may be already connected
-		if (socket._timedOutHandlerSet) {
-			clear();
+		// Socket may come from Agent pool and may be already connected.
+		if (!(socket.connecting || socket._connecting)) {
+			connect.call(socket);
 			return;
 		}
 
-		socket._timedOutHandlerSet = true;
-		socket.on('connect', connect);
+		socket.once('connect', connect);
 	});
 
 	function clear() {


### PR DESCRIPTION
It is possible that a socket is already connected but the `_timedOutHandlerSet` property hasn't been added yet because it is the first time that the socket is being used. When this happen the `connect` event is not emitted as the socket is already connected and the connect timer is not cleared.

This patch restores the `socket.connecting` check in order to correctly handle cases where the socket is already connected.

This will break nock compatibility again but maybe the issue should be fixed in nock and not here.